### PR TITLE
fix: harden OAuth 2.1 token endpoint and fix Vercel preview compatibi…

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { ALLOWED_SCOPES } from "@/lib/route/constants";
+import { getOAuthBaseUrl } from "@/lib/oauth/base-url";
 
-export async function GET() {
-  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+export async function GET(request: NextRequest) {
+  const baseUrl = getOAuthBaseUrl(request);
 
   return NextResponse.json({
     issuer: baseUrl,
@@ -14,6 +15,10 @@ export async function GET() {
     response_modes_supported: ["query"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
-    token_endpoint_auth_methods_supported: ["none"],
+    token_endpoint_auth_methods_supported: [
+      "none",
+      "client_secret_post",
+      "client_secret_basic",
+    ],
   });
 }

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { ALLOWED_SCOPES } from "@/lib/route/constants";
+import { getOAuthBaseUrl } from "@/lib/oauth/base-url";
 
-export async function GET() {
-  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+export async function GET(request: NextRequest) {
+  const baseUrl = getOAuthBaseUrl(request);
 
   return NextResponse.json({
     resource: `${baseUrl}/api/mcp`,

--- a/app/api/mcp/authorize/route.ts
+++ b/app/api/mcp/authorize/route.ts
@@ -8,6 +8,7 @@ import { ConsentChallenge } from "@/models/consent-challenge.model";
 import { User } from "@/models/user.model";
 import { ALLOWED_SCOPES } from "@/lib/route/constants";
 import { renderConsentPage } from "@/lib/oauth/consent-page";
+import { getOAuthBaseUrl } from "@/lib/oauth/base-url";
 
 export async function GET(request: NextRequest) {
   try {
@@ -54,7 +55,7 @@ export async function GET(request: NextRequest) {
     if (!session?.user?.email) {
       const params = new URLSearchParams(searchParams);
       const callbackUrl = `/api/mcp/authorize?${params.toString()}`;
-      const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+      const baseUrl = getOAuthBaseUrl(request);
       const signInUrl = new URL("/api/auth/signin", baseUrl);
       signInUrl.searchParams.set("callbackUrl", callbackUrl);
       return NextResponse.redirect(signInUrl);
@@ -157,7 +158,7 @@ export async function POST(request: NextRequest) {
     redirectUrl.searchParams.set("code", code);
     if (challenge.state) redirectUrl.searchParams.set("state", challenge.state);
 
-    return NextResponse.redirect(redirectUrl);
+    return NextResponse.redirect(redirectUrl, { status: 303 });
   } catch (err) {
     console.error("[MCP_AUTHORIZE_ERROR]", err);
     return NextResponse.json(

--- a/app/api/mcp/register/route.ts
+++ b/app/api/mcp/register/route.ts
@@ -48,6 +48,25 @@ export async function POST(request: NextRequest) {
     const tokenEndpointAuthMethod = body.token_endpoint_auth_method;
     const scope = body.scope;
 
+    const SUPPORTED_AUTH_METHODS = [
+      "none",
+      "client_secret_post",
+      "client_secret_basic",
+    ];
+
+    if (
+      tokenEndpointAuthMethod &&
+      !SUPPORTED_AUTH_METHODS.includes(tokenEndpointAuthMethod)
+    ) {
+      return NextResponse.json(
+        {
+          error: "invalid_client_metadata",
+          error_description: `Unsupported token_endpoint_auth_method. Supported: ${SUPPORTED_AUTH_METHODS.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+
     if (
       !redirectUris ||
       !Array.isArray(redirectUris) ||
@@ -64,7 +83,21 @@ export async function POST(request: NextRequest) {
 
     for (const uri of redirectUris) {
       try {
-        new URL(uri);
+        const parsed = new URL(uri);
+        if (
+          parsed.protocol !== "https:" &&
+          parsed.hostname !== "localhost" &&
+          parsed.hostname !== "127.0.0.1" &&
+          parsed.hostname !== "[::1]"
+        ) {
+          return NextResponse.json(
+            {
+              error: "invalid_client_metadata",
+              error_description: "redirect_uri must be HTTPS (except localhost)",
+            },
+            { status: 400 },
+          );
+        }
       } catch {
         return NextResponse.json(
           {

--- a/app/api/mcp/register/route.ts
+++ b/app/api/mcp/register/route.ts
@@ -93,7 +93,8 @@ export async function POST(request: NextRequest) {
           return NextResponse.json(
             {
               error: "invalid_client_metadata",
-              error_description: "redirect_uri must be HTTPS (except localhost)",
+              error_description:
+                "redirect_uri must be HTTPS (except localhost)",
             },
             { status: 400 },
           );

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -34,7 +34,9 @@ export async function POST(request: NextRequest) {
         ? [new URL(process.env.NEXTAUTH_URL).host]
         : []),
       ...(process.env.MCP_ALLOWED_HOSTS
-        ? process.env.MCP_ALLOWED_HOSTS.split(",").map((h) => h.trim()).filter(Boolean)
+        ? process.env.MCP_ALLOWED_HOSTS.split(",")
+            .map((h) => h.trim())
+            .filter(Boolean)
         : []),
       ...(process.env.VERCEL_URL ? [process.env.VERCEL_URL] : []),
       "localhost",

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -6,6 +6,7 @@ import {
 import { validateAccessToken } from "@/mcp/oauth";
 import { toAuthInfo } from "@/mcp/types";
 import { createFactory } from "@/mcp/server";
+import { getOAuthBaseUrl } from "@/lib/oauth/base-url";
 
 const handler = createMcpHandler(createFactory(), { legacy: "stateless" });
 
@@ -24,9 +25,18 @@ export async function OPTIONS() {
 
 export async function POST(request: NextRequest) {
   try {
-    const metaUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+    const metaUrl = getOAuthBaseUrl(request);
     const allowedHosts = [
-      new URL(metaUrl).host,
+      ...(process.env.MCP_BASE_URL
+        ? [new URL(process.env.MCP_BASE_URL).host]
+        : []),
+      ...(process.env.NEXTAUTH_URL
+        ? [new URL(process.env.NEXTAUTH_URL).host]
+        : []),
+      ...(process.env.MCP_ALLOWED_HOSTS
+        ? process.env.MCP_ALLOWED_HOSTS.split(",").map((h) => h.trim()).filter(Boolean)
+        : []),
+      ...(process.env.VERCEL_URL ? [process.env.VERCEL_URL] : []),
       "localhost",
       "127.0.0.1",
       "[::1]",

--- a/app/api/mcp/token/route.ts
+++ b/app/api/mcp/token/route.ts
@@ -21,7 +21,10 @@ export async function POST(request: NextRequest) {
     } else {
       const fd = await request.formData();
       body = Object.fromEntries(
-        Array.from(fd.entries(), ([k, v]) => [k, typeof v === "string" ? v : v.name]),
+        Array.from(fd.entries(), ([k, v]) => [
+          k,
+          typeof v === "string" ? v : v.name,
+        ]),
       );
     }
 
@@ -89,7 +92,10 @@ export async function POST(request: NextRequest) {
       if (authMethod === "client_secret_post") {
         if (!clientId || clientId !== authCode.clientId) {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Invalid client credentials" },
+            {
+              error: "invalid_client",
+              error_description: "Invalid client credentials",
+            },
             { status: 400 },
           );
         }
@@ -101,7 +107,10 @@ export async function POST(request: NextRequest) {
             Buffer.from(registration.clientSecret).length
         ) {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Invalid client secret" },
+            {
+              error: "invalid_client",
+              error_description: "Invalid client secret",
+            },
             { status: 400 },
           );
         }
@@ -112,7 +121,10 @@ export async function POST(request: NextRequest) {
           )
         ) {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Invalid client secret" },
+            {
+              error: "invalid_client",
+              error_description: "Invalid client secret",
+            },
             { status: 400 },
           );
         }
@@ -120,26 +132,40 @@ export async function POST(request: NextRequest) {
         const authHeader = request.headers.get("authorization") ?? "";
         if (!authHeader.startsWith("Basic ")) {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Basic authentication required" },
+            {
+              error: "invalid_client",
+              error_description: "Basic authentication required",
+            },
             { status: 400 },
           );
         }
         let headerClientId: string;
         let secret: string;
         try {
-          const decoded = Buffer.from(authHeader.slice(6), "base64url").toString();
+          const decoded = Buffer.from(
+            authHeader.slice(6),
+            "base64url",
+          ).toString();
           const colon = decoded.indexOf(":");
-          headerClientId = decodeURIComponent(colon >= 0 ? decoded.slice(0, colon) : decoded);
+          headerClientId = decodeURIComponent(
+            colon >= 0 ? decoded.slice(0, colon) : decoded,
+          );
           secret = colon >= 0 ? decoded.slice(colon + 1) : decoded;
         } catch {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Invalid client credentials" },
+            {
+              error: "invalid_client",
+              error_description: "Invalid client credentials",
+            },
             { status: 400 },
           );
         }
         if (headerClientId !== authCode.clientId) {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Invalid client credentials" },
+            {
+              error: "invalid_client",
+              error_description: "Invalid client credentials",
+            },
             { status: 400 },
           );
         }
@@ -149,7 +175,10 @@ export async function POST(request: NextRequest) {
             Buffer.from(registration.clientSecret).length
         ) {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Invalid client secret" },
+            {
+              error: "invalid_client",
+              error_description: "Invalid client secret",
+            },
             { status: 400 },
           );
         }
@@ -160,7 +189,10 @@ export async function POST(request: NextRequest) {
           )
         ) {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Invalid client secret" },
+            {
+              error: "invalid_client",
+              error_description: "Invalid client secret",
+            },
             { status: 400 },
           );
         }
@@ -225,7 +257,10 @@ export async function POST(request: NextRequest) {
       const refreshToken = body.refresh_token ?? null;
       if (!refreshToken) {
         return NextResponse.json(
-          { error: "invalid_grant", error_description: "Missing refresh_token" },
+          {
+            error: "invalid_grant",
+            error_description: "Missing refresh_token",
+          },
           { status: 400 },
         );
       }
@@ -233,7 +268,10 @@ export async function POST(request: NextRequest) {
       const tokenInfo = await lookupRefreshToken(refreshToken);
       if (!tokenInfo) {
         return NextResponse.json(
-          { error: "invalid_grant", error_description: "Invalid or expired refresh token" },
+          {
+            error: "invalid_grant",
+            error_description: "Invalid or expired refresh token",
+          },
           { status: 400 },
         );
       }
@@ -261,7 +299,10 @@ export async function POST(request: NextRequest) {
         if (authMethod === "client_secret_post") {
           if (!clientId || clientId !== tokenInfo.clientId) {
             return NextResponse.json(
-              { error: "invalid_client", error_description: "Invalid client credentials" },
+              {
+                error: "invalid_client",
+                error_description: "Invalid client credentials",
+              },
               { status: 400 },
             );
           }
@@ -273,7 +314,10 @@ export async function POST(request: NextRequest) {
               Buffer.from(registration.clientSecret).length
           ) {
             return NextResponse.json(
-              { error: "invalid_client", error_description: "Invalid client secret" },
+              {
+                error: "invalid_client",
+                error_description: "Invalid client secret",
+              },
               { status: 400 },
             );
           }
@@ -284,7 +328,10 @@ export async function POST(request: NextRequest) {
             )
           ) {
             return NextResponse.json(
-              { error: "invalid_client", error_description: "Invalid client secret" },
+              {
+                error: "invalid_client",
+                error_description: "Invalid client secret",
+              },
               { status: 400 },
             );
           }
@@ -292,26 +339,40 @@ export async function POST(request: NextRequest) {
           const authHeader = request.headers.get("authorization") ?? "";
           if (!authHeader.startsWith("Basic ")) {
             return NextResponse.json(
-              { error: "invalid_client", error_description: "Basic authentication required" },
+              {
+                error: "invalid_client",
+                error_description: "Basic authentication required",
+              },
               { status: 400 },
             );
           }
           let headerClientId: string;
           let secret: string;
           try {
-            const decoded = Buffer.from(authHeader.slice(6), "base64url").toString();
+            const decoded = Buffer.from(
+              authHeader.slice(6),
+              "base64url",
+            ).toString();
             const colon = decoded.indexOf(":");
-            headerClientId = decodeURIComponent(colon >= 0 ? decoded.slice(0, colon) : decoded);
+            headerClientId = decodeURIComponent(
+              colon >= 0 ? decoded.slice(0, colon) : decoded,
+            );
             secret = colon >= 0 ? decoded.slice(colon + 1) : decoded;
           } catch {
             return NextResponse.json(
-              { error: "invalid_client", error_description: "Invalid client credentials" },
+              {
+                error: "invalid_client",
+                error_description: "Invalid client credentials",
+              },
               { status: 400 },
             );
           }
           if (headerClientId !== tokenInfo.clientId) {
             return NextResponse.json(
-              { error: "invalid_client", error_description: "Invalid client credentials" },
+              {
+                error: "invalid_client",
+                error_description: "Invalid client credentials",
+              },
               { status: 400 },
             );
           }
@@ -321,7 +382,10 @@ export async function POST(request: NextRequest) {
               Buffer.from(registration.clientSecret).length
           ) {
             return NextResponse.json(
-              { error: "invalid_client", error_description: "Invalid client secret" },
+              {
+                error: "invalid_client",
+                error_description: "Invalid client secret",
+              },
               { status: 400 },
             );
           }
@@ -332,13 +396,19 @@ export async function POST(request: NextRequest) {
             )
           ) {
             return NextResponse.json(
-              { error: "invalid_client", error_description: "Invalid client secret" },
+              {
+                error: "invalid_client",
+                error_description: "Invalid client secret",
+              },
               { status: 400 },
             );
           }
         } else if (authMethod !== "none") {
           return NextResponse.json(
-            { error: "invalid_client", error_description: "Unsupported token_endpoint_auth_method" },
+            {
+              error: "invalid_client",
+              error_description: "Unsupported token_endpoint_auth_method",
+            },
             { status: 400 },
           );
         }
@@ -347,7 +417,10 @@ export async function POST(request: NextRequest) {
       const tokens = await rotateRefreshToken(refreshToken);
       if (!tokens) {
         return NextResponse.json(
-          { error: "server_error", error_description: "Failed to rotate refresh token" },
+          {
+            error: "server_error",
+            error_description: "Failed to rotate refresh token",
+          },
           { status: 500 },
         );
       }

--- a/app/api/mcp/token/route.ts
+++ b/app/api/mcp/token/route.ts
@@ -6,20 +6,32 @@ import { ClientRegistration } from "@/models/client-registration.model";
 import {
   createAccessToken,
   rotateRefreshToken,
+  lookupRefreshToken,
   ACCESS_TOKEN_TTL_SECONDS,
 } from "@/mcp/oauth";
 
 export async function POST(request: NextRequest) {
   try {
     await connectToDatabase();
-    const body = await request.formData();
-    const grantType = body.get("grant_type") as string | null;
+
+    const ct = request.headers.get("content-type") ?? "";
+    let body: Record<string, string>;
+    if (ct.includes("application/json")) {
+      body = (await request.json()) as Record<string, string>;
+    } else {
+      const fd = await request.formData();
+      body = Object.fromEntries(
+        Array.from(fd.entries(), ([k, v]) => [k, typeof v === "string" ? v : v.name]),
+      );
+    }
+
+    const grantType = body.grant_type ?? null;
 
     if (grantType === "authorization_code") {
-      const code = body.get("code") as string | null;
-      const codeVerifier = body.get("code_verifier") as string | null;
-      const redirectUri = body.get("redirect_uri") as string | null;
-      const clientId = body.get("client_id") as string | null;
+      const code = body.code ?? null;
+      const codeVerifier = body.code_verifier ?? null;
+      const redirectUri = body.redirect_uri ?? null;
+      const clientId = body.client_id ?? null;
 
       if (!code || !codeVerifier) {
         return NextResponse.json(
@@ -66,17 +78,100 @@ export async function POST(request: NextRequest) {
       const registration = await ClientRegistration.findOne({
         clientId: authCode.clientId,
       });
-      if (registration) {
-        const method = registration.tokenEndpointAuthMethod;
-        if (method !== "none") {
+      if (!registration) {
+        return NextResponse.json(
+          { error: "invalid_client", error_description: "Unknown client" },
+          { status: 400 },
+        );
+      }
+
+      const authMethod = registration.tokenEndpointAuthMethod ?? "none";
+      if (authMethod === "client_secret_post") {
+        if (!clientId || clientId !== authCode.clientId) {
           return NextResponse.json(
-            {
-              error: "invalid_client",
-              error_description: "Unsupported token_endpoint_auth_method",
-            },
+            { error: "invalid_client", error_description: "Invalid client credentials" },
             { status: 400 },
           );
         }
+        const secret = body.client_secret ?? null;
+        if (
+          !secret ||
+          !registration.clientSecret ||
+          Buffer.from(secret).length !==
+            Buffer.from(registration.clientSecret).length
+        ) {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Invalid client secret" },
+            { status: 400 },
+          );
+        }
+        if (
+          !crypto.timingSafeEqual(
+            Buffer.from(secret),
+            Buffer.from(registration.clientSecret),
+          )
+        ) {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Invalid client secret" },
+            { status: 400 },
+          );
+        }
+      } else if (authMethod === "client_secret_basic") {
+        const authHeader = request.headers.get("authorization") ?? "";
+        if (!authHeader.startsWith("Basic ")) {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Basic authentication required" },
+            { status: 400 },
+          );
+        }
+        let headerClientId: string;
+        let secret: string;
+        try {
+          const decoded = Buffer.from(authHeader.slice(6), "base64url").toString();
+          const colon = decoded.indexOf(":");
+          headerClientId = decodeURIComponent(colon >= 0 ? decoded.slice(0, colon) : decoded);
+          secret = colon >= 0 ? decoded.slice(colon + 1) : decoded;
+        } catch {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Invalid client credentials" },
+            { status: 400 },
+          );
+        }
+        if (headerClientId !== authCode.clientId) {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Invalid client credentials" },
+            { status: 400 },
+          );
+        }
+        if (
+          !registration.clientSecret ||
+          Buffer.from(secret).length !==
+            Buffer.from(registration.clientSecret).length
+        ) {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Invalid client secret" },
+            { status: 400 },
+          );
+        }
+        if (
+          !crypto.timingSafeEqual(
+            Buffer.from(secret),
+            Buffer.from(registration.clientSecret),
+          )
+        ) {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Invalid client secret" },
+            { status: 400 },
+          );
+        }
+      } else if (authMethod !== "none") {
+        return NextResponse.json(
+          {
+            error: "invalid_client",
+            error_description: "Unsupported token_endpoint_auth_method",
+          },
+          { status: 400 },
+        );
       }
 
       const expectedChallenge = crypto
@@ -84,6 +179,18 @@ export async function POST(request: NextRequest) {
         .update(codeVerifier)
         .digest("base64url");
 
+      if (
+        Buffer.from(expectedChallenge).length !==
+        Buffer.from(authCode.codeChallenge).length
+      ) {
+        return NextResponse.json(
+          {
+            error: "invalid_grant",
+            error_description: "PKCE verification failed",
+          },
+          { status: 400 },
+        );
+      }
       if (
         !crypto.timingSafeEqual(
           Buffer.from(expectedChallenge),
@@ -115,25 +222,133 @@ export async function POST(request: NextRequest) {
     }
 
     if (grantType === "refresh_token") {
-      const refreshToken = body.get("refresh_token") as string | null;
+      const refreshToken = body.refresh_token ?? null;
       if (!refreshToken) {
         return NextResponse.json(
-          {
-            error: "invalid_grant",
-            error_description: "Missing refresh_token",
-          },
+          { error: "invalid_grant", error_description: "Missing refresh_token" },
           { status: 400 },
         );
+      }
+
+      const tokenInfo = await lookupRefreshToken(refreshToken);
+      if (!tokenInfo) {
+        return NextResponse.json(
+          { error: "invalid_grant", error_description: "Invalid or expired refresh token" },
+          { status: 400 },
+        );
+      }
+
+      const clientId = body.client_id ?? tokenInfo.clientId ?? null;
+      if (tokenInfo.clientId && clientId !== tokenInfo.clientId) {
+        return NextResponse.json(
+          { error: "invalid_grant", error_description: "client_id mismatch" },
+          { status: 400 },
+        );
+      }
+
+      if (tokenInfo.clientId) {
+        const registration = await ClientRegistration.findOne({
+          clientId: tokenInfo.clientId,
+        });
+        if (!registration) {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Unknown client" },
+            { status: 400 },
+          );
+        }
+
+        const authMethod = registration.tokenEndpointAuthMethod ?? "none";
+        if (authMethod === "client_secret_post") {
+          if (!clientId || clientId !== tokenInfo.clientId) {
+            return NextResponse.json(
+              { error: "invalid_client", error_description: "Invalid client credentials" },
+              { status: 400 },
+            );
+          }
+          const secret = body.client_secret ?? null;
+          if (
+            !secret ||
+            !registration.clientSecret ||
+            Buffer.from(secret).length !==
+              Buffer.from(registration.clientSecret).length
+          ) {
+            return NextResponse.json(
+              { error: "invalid_client", error_description: "Invalid client secret" },
+              { status: 400 },
+            );
+          }
+          if (
+            !crypto.timingSafeEqual(
+              Buffer.from(secret),
+              Buffer.from(registration.clientSecret),
+            )
+          ) {
+            return NextResponse.json(
+              { error: "invalid_client", error_description: "Invalid client secret" },
+              { status: 400 },
+            );
+          }
+        } else if (authMethod === "client_secret_basic") {
+          const authHeader = request.headers.get("authorization") ?? "";
+          if (!authHeader.startsWith("Basic ")) {
+            return NextResponse.json(
+              { error: "invalid_client", error_description: "Basic authentication required" },
+              { status: 400 },
+            );
+          }
+          let headerClientId: string;
+          let secret: string;
+          try {
+            const decoded = Buffer.from(authHeader.slice(6), "base64url").toString();
+            const colon = decoded.indexOf(":");
+            headerClientId = decodeURIComponent(colon >= 0 ? decoded.slice(0, colon) : decoded);
+            secret = colon >= 0 ? decoded.slice(colon + 1) : decoded;
+          } catch {
+            return NextResponse.json(
+              { error: "invalid_client", error_description: "Invalid client credentials" },
+              { status: 400 },
+            );
+          }
+          if (headerClientId !== tokenInfo.clientId) {
+            return NextResponse.json(
+              { error: "invalid_client", error_description: "Invalid client credentials" },
+              { status: 400 },
+            );
+          }
+          if (
+            !registration.clientSecret ||
+            Buffer.from(secret).length !==
+              Buffer.from(registration.clientSecret).length
+          ) {
+            return NextResponse.json(
+              { error: "invalid_client", error_description: "Invalid client secret" },
+              { status: 400 },
+            );
+          }
+          if (
+            !crypto.timingSafeEqual(
+              Buffer.from(secret),
+              Buffer.from(registration.clientSecret),
+            )
+          ) {
+            return NextResponse.json(
+              { error: "invalid_client", error_description: "Invalid client secret" },
+              { status: 400 },
+            );
+          }
+        } else if (authMethod !== "none") {
+          return NextResponse.json(
+            { error: "invalid_client", error_description: "Unsupported token_endpoint_auth_method" },
+            { status: 400 },
+          );
+        }
       }
 
       const tokens = await rotateRefreshToken(refreshToken);
       if (!tokens) {
         return NextResponse.json(
-          {
-            error: "invalid_grant",
-            error_description: "Invalid or expired refresh token",
-          },
-          { status: 400 },
+          { error: "server_error", error_description: "Failed to rotate refresh token" },
+          { status: 500 },
         );
       }
 

--- a/lib/oauth/base-url.ts
+++ b/lib/oauth/base-url.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+
+export function getOAuthBaseUrl(request?: NextRequest): string {
+  if (process.env.MCP_BASE_URL) return process.env.MCP_BASE_URL;
+
+  if (process.env.NEXTAUTH_URL) return process.env.NEXTAUTH_URL;
+
+  if (request) {
+    const proto = request.headers.get("x-forwarded-proto") ?? "https";
+    const host = request.headers.get("x-forwarded-host");
+    if (host) return `${proto}://${host}`;
+
+    return request.nextUrl.origin;
+  }
+
+  return "http://localhost:3000";
+}

--- a/mcp/oauth.ts
+++ b/mcp/oauth.ts
@@ -49,6 +49,22 @@ export async function createAccessToken(
   return { accessToken, refreshToken };
 }
 
+export async function lookupRefreshToken(
+  rawRefreshToken: string,
+): Promise<{ clientId?: string } | null> {
+  await connectToDatabase();
+
+  const tokenHash = hashToken(rawRefreshToken);
+  const doc = await OAuthToken.findOne({
+    tokenHash,
+    type: "refresh",
+    expiresAt: { $gt: new Date() },
+  });
+
+  if (!doc) return null;
+  return { clientId: doc.clientId };
+}
+
 export async function validateAccessToken(
   rawToken: string,
 ): Promise<TOAuthToken | null> {


### PR DESCRIPTION
…lity

- Fix consent redirect from 307 to 303 so the browser follows with GET to the client's callback URL instead of POST ('Method Not Allowed')
- Support dual-parse (form data + JSON) in token endpoint for MCP SDK clients that send application/json
- Add getOAuthBaseUrl(request) helper — resolves origin from MCP_BASE_URL, NEXTAUTH_URL, or request headers; all .well-known metadata and OAuth redirects now use correct preview origin
- Host validation uses only env vars (MCP_ALLOWED_HOSTS, VERCEL_URL, MCP_BASE_URL, NEXTAUTH_URL) — no request-derived values
- Advertise and accept client_secret_post + client_secret_basic in addition to none; validate client id and secret on both authorization_code and refresh_token grants
- Guard all timingSafeEqual calls with length checks to prevent throws on mismatch becoming 500s
- Catch malformed Basic header parsing (bad percent-encoding, bad base64) and return invalid_client instead of server_error
- Require HTTPS for registered redirect URIs (except localhost)